### PR TITLE
Fix the composer provide rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "guzzlehttp/psr7": "^1.5"
     },
     "provide": {
-        "psr/http-factory": "^1.0"
+        "psr/http-factory-implementation": "1.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This package does not provide the code of the psr/http-factory package (which defines interfaces). It provides psr/http-factory-implementation which is the virtual package to represent implementations of the interface.
Providing the wrong package while also requiring it creates issues with Composer 2, because the solver will consider that install psr/http-factory is not necessary as it is already provided.

Refs composer/composer#9316